### PR TITLE
bump travis distribution to xenial

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,4 @@
+dist: xenial
 language: go
 sudo: false
 go:


### PR DESCRIPTION
according to golang/go#31293 there is an incompatibility between newest gcc and cgo